### PR TITLE
I changed urlencode from 'function get' to 'function finish' because …

### DIFF
--- a/QRCode.class.php
+++ b/QRCode.class.php
@@ -317,6 +317,7 @@ class QRCode
     public function finish()
     {
         $this->_sData .= 'END:VCARD';
+        $this->_sData = urlencode($this->_sData);
         return $this;
     }
 
@@ -330,7 +331,6 @@ class QRCode
      */
     public function get($iSize = 150, $sECLevel = 'L', $iMargin = 1)
     {
-        $this->_sData = urlencode($this->_sData);
         return self::API_URL . $iSize . 'x' . $iSize . '&cht=qr&chld=' . $sECLevel . '|' . $iMargin . '&chl=' . $this->_sData;
     }
 


### PR DESCRIPTION
Hi Pierre.
I changed urlencode from 'function get' to 'function finish' because if you use 'display' or 'get' more than once or 'get' after 'display' or 'display' after 'get', the data was encoded more once, making a qrcode mistake.